### PR TITLE
add #42 i18nによる日本語化対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ gem "carrierwave"
 gem "fog-aws"
 # 環境変数を管理するため
 gem "dotenv-rails"
+# i18nによる日本語化対応
+gem 'rails-i18n'
+gem 'enum_help'
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       dotenv (= 3.1.2)
       railties (>= 6.1)
     drb (2.2.1)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.13.0)
     excon (0.111.0)
     faraday (2.10.0)
@@ -257,6 +259,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.3.4)
       actionpack (= 7.1.3.4)
       activesupport (= 7.1.3.4)
@@ -341,12 +346,14 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv-rails
+  enum_help
   fog-aws
   jbuilder
   jsbundling-rails
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.4)
+  rails-i18n
   selenium-webdriver
   sorcery
   sprockets-rails

--- a/app/views/children/_form.html.erb
+++ b/app/views/children/_form.html.erb
@@ -1,21 +1,20 @@
 <%= form_with model: @child do |f| %>
-    <%= child.errors.full_messages %>
-    <div class="mb-4">
-      <%= f.label :avatar_image, class: "label" %>
-      <%= f.file_field :avatar_image, class: "file-input file-input-bordered w-full" %>
-      <%= f.hidden_field :avatar_image_cache %>
+  <div class="mb-4">
+    <%= f.label :avatar_image, class: "label" %>
+    <%= f.file_field :avatar_image, class: "file-input file-input-bordered w-full" %>
+    <%= f.hidden_field :avatar_image_cache %>
+  </div>
+  <div class="mb-4">
+    <%= f.label :name, class: "label" %>
+    <%= f.text_field :name, class: "input input-bordered w-full" %>
+  </div>
+  <div class="mb-10">
+    <%= f.label :birthday, class: "label" %>
+    <%= f.date_field :birthday, class: "input input-bordered w-full" %>
+  </div>
+  <div class="m-2">
+    <div class="text-center">
+      <%= f.submit "登録", class: "btn btn-primary w-full" %>
     </div>
-    <div class="mb-4">
-      <%= f.label :name, class: "label" %>
-      <%= f.text_field :name, class: "input input-bordered w-full" %>
-    </div>
-    <div class="mb-10">
-      <%= f.label :birthday, class: "label" %>
-      <%= f.date_field :birthday, class: "input input-bordered w-full" %>
-    </div>
-    <div class="m-2">
-      <div class="text-center">
-        <%= f.submit "登録", class: "btn btn-primary w-full" %>
-      </div>
-    </div>
-  <% end %>
+  </div>
+<% end %>

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -10,7 +10,7 @@
   </div>
   <div class="mb-10">
     <%= f.label :relationship, class: "label" %>
-    <%= f.select :relationship, Profile.relationships.map { |k, v| k }, { include_blank: "指定なし" }, class: "select select-bordered w-full" %>
+    <%= f.select :relationship, Profile.relationships.map { |k, v| I18n.t("enums.profile.relationship.#{k}") }, { include_blank: "指定なし" }, class: "select select-bordered w-full" %>
   </div>
   <div class="m-2">
     <div class="text-center">

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,8 @@ module Myapp
       g.helper false       # helper ファイルを作成しない
       g.test_framework nil # test ファイルを作成しない
     end
+
+    # デフォルトの言語を日本語に設定
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,30 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+      profile: プロフィール
+      child: お子さま
+    attributes:
+      user:
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード確認
+      profile:
+        name: 名前
+        relationship: お子さまとの関係
+        avatar: アイコン
+      child:
+        name: なまえ
+        birthday: 誕生日
+        avatar_image: アイコン
+  enums:
+    profile:
+      relationship:
+        mother: ママ
+        father: パパ
+        grand_mother: おばあちゃん
+        grand_father: おじいちゃん
+        aunt: おばさん
+        uncle: おじさん
+        other: その他親族
+        

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,27 @@
+ja:
+  helpers:
+    submit:
+      create: 登録
+      submit: 保存
+      update: 更新
+    label:
+      email: メールアドレス
+      password: パスワード
+  user_sessions:
+    new:
+      title: ログイン
+      login: ログイン
+      to_register_page: 登録ページへ
+      password_forget: パスワードをお忘れの方はこちら
+  users:
+    new:
+      title: ユーザー登録
+      to_login_page: ログインページへ
+  header:
+    login: ログイン
+    logout: ログアウト
+    board: 掲示板
+    board_index: 掲示板一覧
+    create_board: 掲示板作成
+    bookmark_index: ブックマーク一覧
+    profile: プロフィール


### PR DESCRIPTION
## タイトル
i18nによる日本語化対応
## 概要
i18nを使用し、入力フォームやセレクトボックスの表記を日本語化する
## 関連するissue
closed #42 
## 内容詳細
- [x]  config/application.rbにて言語設定
- [x]  gem 'rails-i18n'のインストール
- [x]  gem 'enum-help'のインストール
- [x]  config/locales/activerecord/ja.ymlの作成
- [x]  config/locales/views/ja.ymlの作成
- [x]  入力フォームの属性のi18n化
- [x]  セレクトボックスの表記をenum-helpを用いて日本語化
    - [x]  app/views/profiles/_form.html.erbのセレクトボックス
## その他
